### PR TITLE
Wire up chat completions endpoint to bs detector

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@josheverett/bullshit-detector": "^1.0.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "next": "15.4.6"


### PR DESCRIPTION
This PR integrates the @josheverett/bullshit-detector package with the chat completions API endpoint as requested in issue #5.

## Changes
- Added `@josheverett/bullshit-detector` dependency to package.json
- Modified `app/api/chat/completions/route.ts` to extract the most recent user message content
- Integrated bullshit detection by passing user message to `detectBullshit()`
- Stream the `truth` field from detector result back to client

Fixes #5

Generated with [Claude Code](https://claude.ai/code)